### PR TITLE
fixed inconsistency : renamed ignore to exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A command line tool to lint your PHP code for syntax errors. Run it from the com
     options:
       -q, --quiet:     disable verbose output
       -b, --blame:     display git blame along with error messages
-      --ignore:        comma separated list of folder patterns to ignore
+      --exclude:        comma separated list of folder patterns to exclude
       -h, --help:      display this help screen
 
 **Examples**
@@ -32,7 +32,7 @@ Find who caused a syntax error: (git is required)
 
 Check files, but ignore certain patterns to speed up the test:
 
-    $ lint --ignore=*views*
+    $ lint --exclude=*views*
     Linting files against PHP 5.3.10-1ubuntu3.2
 
     ............................................................

--- a/scripts/lint
+++ b/scripts/lint
@@ -75,7 +75,7 @@
            'options:' . PHP_EOL .
             '  -q, --quiet:     disable verbose output' . PHP_EOL .
             '  -b, --blame:     display git blame along with error messages' . PHP_EOL .
-            '  -i, --ignore:    comma separated list of folder patterns to ignore' . PHP_EOL .
+            '  --exclude:       comma separated list of folder patterns to exclude' . PHP_EOL .
             '  -h, --help:      display this help screen' . PHP_EOL . PHP_EOL;
       exit(1);
     }


### PR DESCRIPTION
Hi,

Based on your code here https://github.com/dprevite/lint/blob/master/scripts/lint#L191-L196
The option to ignore some paths is "exclude" instead of "ignore". So I send this PR to fix it.

Thanks.